### PR TITLE
nosql용 모듈 추가 및 jpa와 범용으로 사용할 수 있도록 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+def dbType = ":module-jpa"
+//def dbType = ":module-mongodb"
+
 buildscript {
     ext {
         springBootVersion = '2.1.4.RELEASE'
@@ -31,8 +34,12 @@ subprojects {
 
     // 모든 모듈에서 사용하는 라이브러리
     dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-        implementation 'com.querydsl:querydsl-jpa'
+        if (dbType.equals(":module-jpa")) {
+            implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+            implementation 'com.querydsl:querydsl-jpa'
+        } else {
+            implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+        }
         implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'io.springfox:springfox-swagger2:2.6.1'
@@ -52,7 +59,7 @@ subprojects {
 project(':module-common') {
 }
 
-project(":module-jpa") {
+project(dbType) {
     dependencies {
         compile project(':module-common')
     }
@@ -62,6 +69,6 @@ project(':module-web') {
     apply plugin: 'war'
 
     dependencies {
-        compile project(":module-jpa")
+        compile project(dbType)
     }
 }

--- a/module-jpa/src/main/java/com/ymwoo/project/blog/BlogRepositoryImpl.java
+++ b/module-jpa/src/main/java/com/ymwoo/project/blog/BlogRepositoryImpl.java
@@ -7,6 +7,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ymwoo.project.blog.Blog;
+import com.ymwoo.project.blog.BlogSearch;
 import com.ymwoo.project.common.SearchRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/module-mongodb/build.gradle
+++ b/module-mongodb/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'java'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+}
+
+group 'com.ymwoo.project'
+version '0.0.1-SNAPSHOT'
+
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
+}
+
+dependencies {
+}
+
+//querydsl 추가 시작
+def querydslSrcDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    springDataMongo = true
+    querydslSourcesDir = querydslSrcDir
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslSrcDir]
+        }
+    }
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+//querydsl 추가 끝

--- a/module-mongodb/src/main/java/com/ymwoo/project/blog/Blog.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/blog/Blog.java
@@ -1,0 +1,24 @@
+package com.ymwoo.project.blog;
+
+import com.ymwoo.project.common.AbstractObject;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Document
+@Getter
+@Setter
+public class Blog extends AbstractObject <String>
+{
+    @Id
+    private String id;
+
+    private String title;
+
+    private String content;
+
+    private int    hitCount;
+}

--- a/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogRepository.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogRepository.java
@@ -1,10 +1,9 @@
 package com.ymwoo.project.blog;
 
-import com.ymwoo.project.blog.Blog;
-import com.ymwoo.project.blog.BlogSearch;
 import com.ymwoo.project.common.SearchRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
+
 
 public interface BlogRepository extends PagingAndSortingRepository<Blog, String>, QueryByExampleExecutor<Blog>, SearchRepository <Blog, BlogSearch>
 {

--- a/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogRepositoryImpl.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogRepositoryImpl.java
@@ -1,0 +1,128 @@
+package com.ymwoo.project.blog;
+
+import static com.ymwoo.project.blog.QBlog.blog;
+import static org.springframework.util.ObjectUtils.isEmpty;
+
+import java.util.List;
+
+import com.ymwoo.project.common.SearchRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.mongodb.repository.support.SpringDataMongodbQuery;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+public class BlogRepositoryImpl extends QuerydslRepositorySupport implements SearchRepository <Blog, BlogSearch>
+{
+    public BlogRepositoryImpl(MongoOperations mongoOperations)
+    {
+        super(mongoOperations);
+    }
+
+
+
+
+
+    @Override
+    public List<Blog> searchList(BlogSearch search)
+    {
+        return from(blog).where(titleEq(search.getTitle()), contentEq(search.getContent()))
+                         .fetch();
+    }
+
+
+
+
+
+    @Override
+    public Blog searchOne(BlogSearch search)
+    {
+        return from(blog).where(titleEq(search.getTitle()), contentEq(search.getContent()))
+                         .fetchOne();
+    }
+
+
+
+
+
+    @Override
+    public Page<Blog> searchPage(BlogSearch search)
+    {
+        // 정렬 및 페이지
+        Pageable pageable = search.getPageable();
+
+        SpringDataMongodbQuery<Blog> query = from(blog).where(titleEq(search.getTitle()), contentEq(search.getContent()));
+        extractedSort(query, pageable);
+
+        QueryResults<Blog> results = query.offset(pageable.getOffset())
+                                          .limit(pageable.getPageSize())
+                                          .fetchResults();
+
+        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+    }
+
+
+
+
+
+    @Override
+    public Long count(BlogSearch search)
+    {
+        return from(blog).where(titleEq(search.getTitle()), contentEq(search.getContent()))
+                         .fetchCount();
+    }
+
+
+
+
+
+    @Override
+    public Boolean exists(BlogSearch search)
+    {
+        return count(search) > 0;
+    }
+
+
+
+
+
+    private BooleanExpression titleEq(String title)
+    {
+        return isEmpty(title) ? null : blog.title.eq(title);
+    }
+
+
+
+
+
+    private BooleanExpression contentEq(String content)
+    {
+        return isEmpty(content) ? null : blog.content.eq(content);
+    }
+
+
+
+
+
+    private void extractedSort(SpringDataMongodbQuery query, Pageable pageable)
+    {
+        for ( Sort.Order o : pageable.getSort() )
+        {
+            PathBuilder<Blog> pathBuilder = new PathBuilder<>(blog.getType(), blog.getMetadata());
+            query.orderBy(new OrderSpecifier(o.isAscending() ? Order.ASC : Order.DESC, pathBuilder.get(o.getProperty())));
+        }
+    }
+}

--- a/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogSearch.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/blog/BlogSearch.java
@@ -1,0 +1,17 @@
+package com.ymwoo.project.blog;
+
+
+import com.ymwoo.project.common.AbstractSearch;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class BlogSearch extends AbstractSearch
+{
+    private String title;
+
+    private String content;
+}

--- a/module-mongodb/src/main/java/com/ymwoo/project/common/AbstractObject.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/common/AbstractObject.java
@@ -1,0 +1,45 @@
+package com.ymwoo.project.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.domain.Persistable;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class AbstractObject<ID> implements Persistable<ID>
+{
+    private String        owner;
+
+    // TODO 스프링 데이터 Auditing 적용 예정
+    @CreatedDate
+    private LocalDateTime createdDateTime;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDateTime;
+
+    @Version
+    protected Long        version;
+
+    @Override
+    public boolean isNew()
+    {
+        return getId() == null;
+    }
+
+
+
+
+
+    public void copyBaseProperties(final AbstractObject<ID> from)
+    {
+        setCreatedDateTime(from.getCreatedDateTime());
+        setModifiedDateTime(from.getModifiedDateTime());
+        setVersion(from.getVersion());
+    }
+}

--- a/module-mongodb/src/main/java/com/ymwoo/project/config/DatabaseConfig.java
+++ b/module-mongodb/src/main/java/com/ymwoo/project/config/DatabaseConfig.java
@@ -1,0 +1,52 @@
+package com.ymwoo.project.config;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoAuditing
+@EnableMongoRepositories(basePackages = "com.ymwoo.project.*")
+public class DatabaseConfig
+{
+    @Autowired
+    private MappingMongoConverter mappingMongoConverter;
+
+    @PostConstruct
+    public void init()
+    {
+        this.mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+
+
+
+
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GridFsTemplate getGridFsTemplate(MongoDbFactory mongoDatabaseFactory, MongoTemplate mongoTemplate)
+    {
+        return new GridFsTemplate(mongoDatabaseFactory, mongoTemplate.getConverter());
+    }
+
+
+
+
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDbFactory dbFactory)
+    {
+        return new MongoTransactionManager(dbFactory);
+    }
+}

--- a/module-web/src/main/resources/application-test-mongodb.yml
+++ b/module-web/src/main/resources/application-test-mongodb.yml
@@ -1,0 +1,13 @@
+spring:
+  data:
+    mongodb:
+      database: blog-test
+      uri: mongodb://127.0.0.1:27017,127.0.0.1:27018,127.0.0.1:27019/?replicaSet=rs0&connectTimeoutMS=5000&waitQueueMultiple=50
+      grid-fs-database: gridFs
+      max-connection-idle-time: 30000
+      min-connections-per-host: 30
+      connections-per-host: 500
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/module-web/src/main/resources/application.yml
+++ b/module-web/src/main/resources/application.yml
@@ -1,3 +1,4 @@
 spring:
   profiles:
     active: local-jpa
+#    active: local-mongodb

--- a/module-web/src/test/resources/application-test-mongodb.yml
+++ b/module-web/src/test/resources/application-test-mongodb.yml
@@ -1,0 +1,13 @@
+spring:
+  data:
+    mongodb:
+      database: blog-test
+      uri: mongodb://127.0.0.1:27017,127.0.0.1:27018,127.0.0.1:27019/?replicaSet=rs0&connectTimeoutMS=5000&waitQueueMultiple=50
+      grid-fs-database: gridFs
+      max-connection-idle-time: 30000
+      min-connections-per-host: 30
+      connections-per-host: 500
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/module-web/src/test/resources/application.yml
+++ b/module-web/src/test/resources/application.yml
@@ -1,3 +1,4 @@
 spring:
   profiles:
     active: test-jpa
+#    active: test-mongodb

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'standard'
 include 'module-common'
-include 'module-jpa'
 include 'module-web'
+include 'module-jpa'
+//include 'module-mongodb'
 


### PR DESCRIPTION
# module-mongodb 추가
 - mongoDB 용으로 queryDsl 환경 구성
 - queryDsl구성으로 build.gradle에 querydsl셋팅 추가
 - mongoDB DatabaseConfig 셋팅
 - jpa와 mongo는 VO에서 서로 다른 어노테이션 사용하기 때문에 AbstructObject를 rdb, nosql 각 각 모듈에 사용되게 수정

# module-web
 - db셋팅 별 환경을 사용할 수 있도록 application 분리
  > spring.profiles.active 값을 nosql 또는 rdb로 분리하여 사용
 - rdb, nosql 겸용으로 Tests파일이 동작 할 수 있도록 소스 수정

# gradle설정 파일 변경
 - build.gradle에서 dbType을 변수로 관리하여 모듈 의존성 관리
 - settings.gradle에서 사용이 필요한 db모듈 include 관리